### PR TITLE
[feat] chat messages query

### DIFF
--- a/src/molecule/SideBarLayout.tsx
+++ b/src/molecule/SideBarLayout.tsx
@@ -5,9 +5,8 @@ export interface SideBarLayoutProps {
 function SideBarLayout({ children }: SideBarLayoutProps) {
   return (
     <div
-      className="col-span-1 col-start-2 row-span-2 row-start-2 shrink-0
-                 flex h-full w-[370px] flex-col items-start justify-start
-                 border-l border-neutral-400 bg-neutral-600 font-pixel text-white"
+      className="flex h-full w-[370px] shrink-0 flex-col items-start justify-start
+                 overflow-y-auto border-l border-neutral-400 bg-neutral-600 font-pixel text-white"
     >
       {children}
     </div>

--- a/src/organism/ChatingRoom.tsx
+++ b/src/organism/ChatingRoom.tsx
@@ -46,8 +46,7 @@ function useChatMessages(roomId: string) {
       }
       return [];
     },
-    retry: false,
-    staleTime: Infinity,
+    refetchOnWindowFocus: false,
   });
 
   return data;

--- a/src/organism/ChatingRoom.tsx
+++ b/src/organism/ChatingRoom.tsx
@@ -123,43 +123,40 @@ export default function ChatingRoom({ roomId, setRoom_Id }: ChatProps) {
   const { messages, socket } = useChat(roomId);
 
   return (
-    <div
-      className="flex h-full w-full flex-col
-										items-start justify-start border-l border-neutral-400 bg-neutral-600 font-pixel
-										text-sm text-white"
-    >
-      <div className="flex h-10 w-full items-center justify-between border-b border-inherit bg-neutral-800 px-3">
+    <>
+      <div className="flex h-fit w-full items-center justify-between border-b border-inherit bg-neutral-800 p-2">
         {roomId}
         <button onClick={() => setRoom_Id(null)} className="px-1">
           ⬅
         </button>
       </div>
-      <div className="flex h-full w-full flex-col items-start justify-end border-b border-inherit">
-        <div className="flex h-full w-full flex-col items-start justify-end border-b border-inherit">
+      <div className="h-full w-full grow overflow-y-auto border-b border-inherit">
+        <ul className="flex h-fit w-full flex-col items-start justify-start">
           {messages?.map((message) => (
             <li
               key={message.room_msg_id}
+              className="p-1 px-5 h-fit w-full text-xs break-words"
             >{`${message.sender_id}: ${message.payload}`}</li>
           ))}
-        </div>
-        <div className="h-30 flex items-end justify-end">
-          <textarea
-            placeholder="plase input here."
-            className="h-20 w-full resize-none border-none bg-neutral-300 text-black"
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-          />
-          <button
-            className="h-full border-b border-inherit bg-neutral-800 px-3"
-            onClick={() => {
-              socket.emit('publish', { room: roomId, payload: content });
-              setContent('');
-            }}
-          >
-            send
-          </button>
-        </div>
+        </ul>
       </div>
-    </div>
+      <div className="flex">
+        <textarea
+          placeholder="plase input here."
+          className="h-20 w-full resize-none border-none bg-neutral-300 text-black"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <button
+          className="h-full border-b border-inherit bg-neutral-800 px-3"
+          onClick={() => {
+            socket.emit('publish', { room: roomId, payload: content });
+            setContent('');
+          }}
+        >
+          send
+        </button>
+      </div>
+    </>
   );
 }

--- a/src/organism/ChatingRoom.tsx
+++ b/src/organism/ChatingRoom.tsx
@@ -29,7 +29,7 @@ interface SubscribeData {
 interface Message {
   room_msg_id: number;
   room_id: string;
-  sender_id: string;
+  sender: string;
   payload: string;
   created: Date;
 }
@@ -74,9 +74,9 @@ function useSocketRef(url: string) {
 }
 
 function useChat(roomId: string) {
-  const { data: messages } = useChatMessages(roomId);
   const queryClient = useQueryClient();
   const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:9999`);
+  const { data: messages } = useChatMessages(roomId);
 
   useEffect(() => {
     const socket = socketRef.current;
@@ -88,7 +88,7 @@ function useChat(roomId: string) {
           const newMessage: Message = {
             room_msg_id: prevMsg ? prevMsg.length + 1 : 1,
             room_id: roomId,
-            sender_id: data.sender?.nickname,
+            sender: data.sender?.nickname,
             payload: data.payload,
             created: new Date(),
           };
@@ -150,7 +150,7 @@ export default function ChatingRoom({ roomId, setRoom_Id }: ChatProps) {
             <li
               key={message.room_msg_id}
               className="p-1 px-5 h-fit w-full text-xs break-words"
-            >{`${message.sender_id}: ${message.payload}`}</li>
+            >{`${message.sender}: ${message.payload}`}</li>
           ))}
         </ul>
       </div>

--- a/src/organism/ChatingRoom.tsx
+++ b/src/organism/ChatingRoom.tsx
@@ -117,9 +117,24 @@ function useChat(roomId: string) {
   return { messages, socket: socketRef.current };
 }
 
+function useAutoScroll(dependency: unknown) {
+  const autoScrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scrollElement = autoScrollRef.current;
+    if (scrollElement) {
+      // FIX: 맨 아래를 보고 있을 때만 동작하게 하기
+      scrollElement.scrollTop = scrollElement.scrollHeight;
+    }
+  }, [dependency])
+
+  return autoScrollRef;
+}
+
 export default function ChatingRoom({ roomId, setRoom_Id }: ChatProps) {
   const [content, setContent] = useState('');
   const { messages, socket } = useChat(roomId);
+  const autoScrollRef = useAutoScroll(messages);
 
   return (
     <>
@@ -129,7 +144,7 @@ export default function ChatingRoom({ roomId, setRoom_Id }: ChatProps) {
           ⬅
         </button>
       </div>
-      <div className="h-full w-full grow overflow-y-auto border-b border-inherit">
+      <div ref={autoScrollRef} className="h-full w-full grow overflow-y-auto border-b border-inherit">
         <ul className="flex h-fit w-full flex-col items-start justify-start">
           {messages?.map((message) => (
             <li

--- a/src/pages/Temp.tsx
+++ b/src/pages/Temp.tsx
@@ -22,9 +22,9 @@ function Temp() {
 	const [sideState, setSideState] = useState<SidebarItem>("chat");
 
 	return (
-		<div className="bg-neutral-600 flex flex-col w-full h-full relative mx-auto my-0" id="root">
+		<div className="bg-neutral-600 flex flex-col w-full h-full mx-auto my-0">
 			<Nav current={sideState} onChange={setSideState}></Nav>
-			<div className="content-start flex h-full w-full relative">
+			<div className="flex h-full w-full min-h-0">
 				<GameContainer />
 				{sidebarSelector(sideState)}
 			</div>


### PR DESCRIPTION
- 과거 메시지를 불러오는 쿼리 추가
- 이후 실시간 통신으로 채팅을 받으면 react query가 가진 쿼리 데이터에 메시지를 추가
- 채팅이 많아지면 채팅창만 스크롤 되도록 구현
  - 부모 컴포넌트가 줄어들지 않아 화면 전체가 스크롤 되는 문제를 `min-height: 0;` 을 통해 해결
- 새로운 채팅을 받으면 맨 아래로 자동 스크롤