### PR TITLE
Fix send extra newline on chat

### DIFF
--- a/src/organism/ChatingRoom.tsx
+++ b/src/organism/ChatingRoom.tsx
@@ -86,7 +86,10 @@ function useChat(roomId: string) {
         ['chat/room/messages', roomId],
         (prevMsg) => {
           const newMessage: Message = {
-            room_msg_id: prevMsg ? prevMsg.length + 1 : 1,
+            room_msg_id:
+              prevMsg && prevMsg.length
+                ? prevMsg[prevMsg.length - 1].room_msg_id + 1
+                : 1,
             room_id: roomId,
             sender: data.sender?.nickname,
             payload: data.payload,

--- a/src/organism/ChatingRoom.tsx
+++ b/src/organism/ChatingRoom.tsx
@@ -137,7 +137,10 @@ export default function ChatingRoom({ roomId, setRoom_Id }: ChatProps) {
   const autoScrollRef = useAutoScroll(messages);
 
   const sendMessage = () => {
-    socket.emit('publish', { room: roomId, payload: content });
+    const msg = content.trim();
+    if (msg) {
+      socket.emit('publish', { room: roomId, payload: msg });
+    }
     setContent('');
   };
 


### PR DESCRIPTION
# Abstract

- 크롬 브라우저에서 한글 채팅시 빈 줄이 추가로 전송되는 버그 수정
- 채팅 메시지 컴포넌트의 key prop 충돌 수정

## Types of edition

- [x] Bug fix (not modifying existing features)
# Test results

- [x] Compile succeed