### PR TITLE
Refactor create chat form

### DIFF
--- a/src/atom/Button.tsx
+++ b/src/atom/Button.tsx
@@ -6,7 +6,8 @@ export default function Button({ children, className, ...props }: ButtonProps) {
   return (
     <button
       className={`text-sm font-pixel text-white px-4 py-2
-                  focus:outline-none hover:ring hover:ring-slate-100
+                  focus:outline-none enabled:hover:ring enabled:hover:ring-slate-100
+                  disabled:opacity-50
                   ${className}`}
       {...props}
     >

--- a/src/organism/Chat.tsx
+++ b/src/organism/Chat.tsx
@@ -6,28 +6,13 @@ import SideBarLayout from '@/molecule/SideBarLayout';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import SectionList from '@/molecule/SectionList';
 import CreateChatForm from './CreateChatForm';
-import {RoomInfo, roomInfoState} from "@/states/roomInfoState";
+import { RoomInfo, roomInfoState } from '@/states/roomInfoState';
 
-function useAllRooms() {
+function useRoomList(type: 'all' | 'joined') {
   const result = useQuery({
-    queryKey: ['chat/rooms/all'],
+    queryKey: ['chat/rooms', type],
     queryFn: async (): Promise<RoomInfo[]> => {
-      const res = await fetcher('/chat/rooms/all');
-      if (res.ok) {
-        const data = await res.json();
-        return data.rooms;
-      }
-      return [];
-    },
-  });
-  return result;
-}
-
-function useJoinedRooms() {
-  const result = useQuery({
-    queryKey: ['chat/rooms/joined'],
-    queryFn: async (): Promise<RoomInfo[]> => {
-      const res = await fetcher('/chat/rooms/joined');
+      const res = await fetcher(`/chat/rooms/${type}`);
       if (res.ok) {
         const data = await res.json();
         return data.rooms;
@@ -41,8 +26,8 @@ function useJoinedRooms() {
 const Chat = () => {
   const [isOpenForm, setIsOpenForm] = useState(false);
   const [roomInfo, setRoomInfo] = useRecoilState(roomInfoState); //room_id need to be null when user is not in any room
-  const { data: allRooms } = useAllRooms();
-  const { data: joinedRooms } = useJoinedRooms();
+  const { data: allRooms } = useRoomList('all');
+  const { data: joinedRooms } = useRoomList('joined');
 
   const section = [
     {
@@ -83,7 +68,7 @@ const Chat = () => {
               <p className="text-lg">Chat</p>
               <p className="px-1">{isOpenForm ? 'x' : '+'}</p>
             </button>
-            <button className='text-xs'>All/Joined</button>
+            <button className="text-xs">All/Joined</button>
           </div>
           {isOpenForm ? <CreateChatForm /> : null}
           <SectionList

--- a/src/organism/Chat.tsx
+++ b/src/organism/Chat.tsx
@@ -4,6 +4,7 @@ import { fetcher } from '@/hooks/fetcher';
 import SideBarLayout from '@/molecule/SideBarLayout';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import SectionList from '@/molecule/SectionList';
+import CreateChatForm from './CreateChatForm';
 
 export interface Room {
   room_id: string;
@@ -45,6 +46,7 @@ function useJoinedRooms() {
 
 const Chat = () => {
   const [room_id, setRoom_Id] = useState<string | null>(null);
+  const [isOpenForm, setIsOpenForm] = useState(false);
   const { data: allRooms } = useAllRooms();
   const { data: joinedRooms } = useJoinedRooms();
 
@@ -76,7 +78,20 @@ const Chat = () => {
         <ChatingRoom roomId={room_id} setRoom_Id={setRoom_Id} />
       ) : (
         <>
-          <AddChatRoom />
+          <div
+            className="flex h-12 w-full shrink-0 flex-row items-center justify-between
+                       border-b border-neutral-400 bg-neutral-800 px-5"
+          >
+            <button
+              className="flex flex-row items-center justify-start"
+              onClick={() => setIsOpenForm(!isOpenForm)}
+            >
+              <p className="text-lg">Chat</p>
+              <p className="px-1">{isOpenForm ? 'x' : '+'}</p>
+            </button>
+            <button className='text-xs'>All/Joined</button>
+          </div>
+          {isOpenForm ? <CreateChatForm /> : null}
           <SectionList
             sections={section}
             renderItem={(room) => (
@@ -91,70 +106,5 @@ const Chat = () => {
     </SideBarLayout>
   );
 };
-
-function AddChatRoom() {
-  const addChatRoom = useMutation({
-    mutationFn: (event: React.FormEvent<HTMLFormElement>) => {
-      const f = event.target;
-
-      event.preventDefault();
-      return fetcher('/chat/room', {
-        method: 'POST',
-        body: JSON.stringify({
-          room_name: f.room_name.value,
-          room_access: f.room_access.value,
-          room_password: f.room_password.value,
-        }),
-      });
-    },
-  });
-
-  return (
-    <form
-      className="flex h-fit w-full shrink-0 flex-row items-center border-b border-neutral-400 bg-neutral-800"
-      onSubmit={addChatRoom.mutate}
-    >
-      <button className="px-2" type="submit">
-        +
-      </button>
-      <div className="flex w-min flex-col items-center bg-neutral-800">
-        <input
-          className="w-min border-b-4 border-white bg-inherit"
-          name="room_name"
-          type="text"
-          required
-        />
-        <div className="flex flex-row space-y-3 text-xs">
-          <input
-            className="w-min border-b-4 border-white bg-inherit"
-            name="room_access"
-            value="public"
-            type="radio"
-          />
-          <label htmlFor="public">public</label>
-          <input
-            className="w-min border-b-4 border-white bg-inherit"
-            name="room_access"
-            value="protected"
-            type="radio"
-          />
-          <label htmlFor="protected">protected</label>
-          <input
-            className="w-min border-b-4 border-white bg-inherit"
-            name="room_access"
-            value="private"
-            type="radio"
-          />
-          <label htmlFor="private">private</label>
-        </div>
-        <input
-          className="w-min border-b-4 border-white bg-inherit"
-          name="room_password"
-          type="password"
-        />
-      </div>
-    </form>
-  );
-}
 
 export default Chat;

--- a/src/organism/CreateChatForm.tsx
+++ b/src/organism/CreateChatForm.tsx
@@ -1,0 +1,69 @@
+import { fetcher } from "@/hooks/fetcher";
+import { useMutation } from "@tanstack/react-query";
+
+function CreateChatForm() {
+  const addChatRoom = useMutation({
+    mutationFn: (event: React.FormEvent<HTMLFormElement>) => {
+      const f = event.target;
+
+      event.preventDefault();
+      return fetcher('/chat/room', {
+        method: 'POST',
+        body: JSON.stringify({
+          room_name: f.room_name.value,
+          room_access: f.room_access.value,
+          room_password: f.room_password.value,
+        }),
+      });
+    },
+  });
+
+  return (
+    <form
+      className="flex h-fit w-full shrink-0 flex-row items-center border-b border-neutral-400 bg-neutral-800"
+      onSubmit={addChatRoom.mutate}
+    >
+      <button className="px-2" type="submit">
+        +
+      </button>
+      <div className="flex w-min flex-col items-center bg-neutral-800">
+        <input
+          className="w-min border-b-4 border-white bg-inherit"
+          name="room_name"
+          type="text"
+          required
+        />
+        <div className="flex flex-row space-y-3 text-xs">
+          <input
+            className="w-min border-b-4 border-white bg-inherit"
+            name="room_access"
+            value="public"
+            type="radio"
+          />
+          <label htmlFor="public">public</label>
+          <input
+            className="w-min border-b-4 border-white bg-inherit"
+            name="room_access"
+            value="protected"
+            type="radio"
+          />
+          <label htmlFor="protected">protected</label>
+          <input
+            className="w-min border-b-4 border-white bg-inherit"
+            name="room_access"
+            value="private"
+            type="radio"
+          />
+          <label htmlFor="private">private</label>
+        </div>
+        <input
+          className="w-min border-b-4 border-white bg-inherit"
+          name="room_password"
+          type="password"
+        />
+      </div>
+    </form>
+  );
+}
+
+export default CreateChatForm;

--- a/src/organism/CreateChatForm.tsx
+++ b/src/organism/CreateChatForm.tsx
@@ -98,7 +98,11 @@ function CreateChatForm() {
           />
         </div>
       ) : null}
-      <Button className="w-full bg-green-600" type="submit">
+      <Button
+        className="w-full bg-green-600"
+        type="submit"
+        disabled={addChatRoom.isLoading}
+      >
         Create Room
       </Button>
     </form>

--- a/src/organism/CreateChatForm.tsx
+++ b/src/organism/CreateChatForm.tsx
@@ -1,18 +1,24 @@
-import { fetcher } from "@/hooks/fetcher";
-import { useMutation } from "@tanstack/react-query";
+import Button from '@/atom/Button';
+import { fetcher } from '@/hooks/fetcher';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+type ChatAccessType = 'public' | 'protected' | 'private';
 
 function CreateChatForm() {
+  const [name, setName] = useState('');
+  const [accessType, setAccessType] = useState<ChatAccessType>('public');
+  const [password, setPassword] = useState('');
+
   const addChatRoom = useMutation({
     mutationFn: (event: React.FormEvent<HTMLFormElement>) => {
-      const f = event.target;
-
       event.preventDefault();
       return fetcher('/chat/room', {
         method: 'POST',
         body: JSON.stringify({
-          room_name: f.room_name.value,
-          room_access: f.room_access.value,
-          room_password: f.room_password.value,
+          room_name: name,
+          room_access: accessType,
+          room_password: password,
         }),
       });
     },
@@ -20,48 +26,51 @@ function CreateChatForm() {
 
   return (
     <form
-      className="flex h-fit w-full shrink-0 flex-row items-center border-b border-neutral-400 bg-neutral-800"
+      className="flex h-fit w-full shrink-0 flex-col items-center
+                 gap-3 border-b border-neutral-400 bg-neutral-800 p-3"
       onSubmit={addChatRoom.mutate}
+      method="POST"
     >
-      <button className="px-2" type="submit">
-        +
-      </button>
-      <div className="flex w-min flex-col items-center bg-neutral-800">
+      <div className="flex w-full flex-row items-center justify-start">
+        <label htmlFor="room_name">name: </label>
         <input
-          className="w-min border-b-4 border-white bg-inherit"
+          className="w-full border-b-4 border-white bg-inherit"
           name="room_name"
           type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
           required
         />
-        <div className="flex flex-row space-y-3 text-xs">
-          <input
-            className="w-min border-b-4 border-white bg-inherit"
-            name="room_access"
-            value="public"
-            type="radio"
-          />
-          <label htmlFor="public">public</label>
-          <input
-            className="w-min border-b-4 border-white bg-inherit"
-            name="room_access"
-            value="protected"
-            type="radio"
-          />
-          <label htmlFor="protected">protected</label>
-          <input
-            className="w-min border-b-4 border-white bg-inherit"
-            name="room_access"
-            value="private"
-            type="radio"
-          />
-          <label htmlFor="private">private</label>
-        </div>
-        <input
-          className="w-min border-b-4 border-white bg-inherit"
-          name="room_password"
-          type="password"
-        />
       </div>
+      <div className="flex w-full flex-row items-center justify-start">
+        <label htmlFor="room_access">type: </label>
+        <select
+          name="room_access"
+          className="w-full bg-neutral-500 p-1"
+          value={accessType}
+          onChange={(e) => setAccessType(e.target.value as ChatAccessType)}
+        >
+          <option value="public">Public</option>
+          <option value="protected">Protected</option>
+          <option value="private">Private</option>
+        </select>
+      </div>
+      {accessType === 'protected' ? (
+        <div className="flex w-full flex-row items-center justify-start">
+          <label htmlFor="room_password">password: </label>
+          <input
+            className="w-full border-b-4 border-white bg-inherit"
+            name="room_password"
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+      ) : null}
+      <Button className="w-full bg-green-600" type="submit">
+        Create Room
+      </Button>
     </form>
   );
 }

--- a/src/organism/CreateChatForm.tsx
+++ b/src/organism/CreateChatForm.tsx
@@ -28,8 +28,7 @@ function useAddChatRoom(
       });
     },
     onSuccess: async (data) => {
-      queryClient.invalidateQueries({ queryKey: ['chat/rooms/all'] });
-      queryClient.invalidateQueries({ queryKey: ['chat/rooms/joined'] });
+      queryClient.invalidateQueries({ queryKey: ['chat/rooms'] });
       try {
         const { room_id } = await data.json();
         setRoomInfo({


### PR DESCRIPTION
# Abstract

- 채팅방 생성 폼 리팩토링
- `Chat` 컴포넌트도 리팩토링
  - 채팅방 리스트와 채팅방 컴포넌트를 온전히 분리
  - 채팅방에 새로 참가할 경우에만 joined 쿼리 전송
  - joined에 실패할 경우 채팅방 컴포넌트를 렌더링 하지 않음
  - 채팅방 리스트 all/joined를 분리하여 표현

## Types of edition

- [x] Changing feature (modifying existing feature or fixing bug)

# Test results

- [x] Compile succeed
