### PR TITLE
Feat notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.4.3",
+        "react-toastify": "^9.1.1",
         "recoil": "^0.7.6",
         "socket.io-client": "^4.5.3"
       },
@@ -17862,6 +17863,26 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-toastify/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/read-cache": {
@@ -36123,6 +36144,21 @@
       "requires": {
         "@remix-run/router": "1.0.3",
         "react-router": "6.4.3"
+      }
+    },
+    "react-toastify": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.1.tgz",
+      "integrity": "sha512-pkFCla1z3ve045qvjEmn2xOJOy4ZciwRXm1oMPULVkELi5aJdHCN/FHnuqXq8IwGDLB7PPk2/J6uP9D8ejuiRw==",
+      "requires": {
+        "clsx": "^1.1.1"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+          "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
+        }
       }
     },
     "read-cache": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.3",
+    "react-toastify": "^9.1.1",
     "recoil": "^0.7.6",
     "socket.io-client": "^4.5.3"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,8 @@ function App() {
             transition={Slide}
             closeOnClick={false}
             closeButton={true}
+            toastClassName="bg-neutral-900 p-1 w-fit"
+            bodyClassName="font-pixel text-xs text-white p-3 w-full"
           />
         </BrowserRouter>
       </QueryClientProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,8 @@ import Login from '@/pages/Login';
 import SignUp from '@/pages/SignUp';
 import Main from '@/pages/Main';
 
+import 'react-toastify/dist/ReactToastify.min.css';
+
 const queryClient = new QueryClient();
 
 function App() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { RecoilRoot } from "recoil";
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastContainer, Slide } from 'react-toastify';
 
 import Intro from '@/pages/Intro';
 import Login from '@/pages/Login';
@@ -13,14 +14,21 @@ function App() {
   return (
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Intro />} />
-          <Route path="/login/:provider" element={ <Login /> }/>
-          <Route path="/sign-up" element={<SignUp />} />
-          <Route path="/main" element={<Main />} />
-        </Routes>
-      </BrowserRouter>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Intro />} />
+            <Route path="/login/:provider" element={<Login />} />
+            <Route path="/sign-up" element={<SignUp />} />
+            <Route path="/main" element={<Main />} />
+          </Routes>
+          <ToastContainer
+            position="top-center"
+            theme="dark"
+            transition={Slide}
+            closeOnClick={false}
+            closeButton={true}
+          />
+        </BrowserRouter>
       </QueryClientProvider>
     </RecoilRoot>
   );

--- a/src/hooks/dm.ts
+++ b/src/hooks/dm.ts
@@ -1,0 +1,112 @@
+import { useEffect } from "react";
+import { useSetRecoilState } from "recoil";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { dmHistoryState, type DmInfo } from '@/states/dmHistoryState';
+import { useSocketRef } from "./chat";
+import { fetcher } from "./fetcher";
+import { type Friend } from "./friends";
+
+interface Message {
+  sender: Friend;
+  payload: string;
+  created: Date;
+}
+
+interface SubscribeData {
+  sender: Friend;
+  payload: string;
+}
+
+export function useDirectMessages(opponent: string) {
+  const data = useQuery<Message[]>({
+    queryKey: ['dm/messages', opponent],
+    queryFn: async () => {
+      const res = await fetcher(`/dm/${opponent}/messages`);
+
+      if (res.ok) {
+        const data = await res.json();
+        return data.messages;
+      }
+      return [];
+    },
+    refetchOnWindowFocus: false,
+  });
+
+  return data;
+}
+
+export function useDirectMessageSocket(opponent: string) {
+  const queryClient = useQueryClient();
+  const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:9992`);
+  const setDmHistory = useSetRecoilState(dmHistoryState);
+
+  useEffect(() => {
+    const socket = socketRef.current;
+
+    const handleSub = (data: SubscribeData) => {
+      queryClient.setQueryData<Message[]>(
+        ['dm/messages', opponent],
+        (prevMsg) => {
+          const newMessage: Message = {
+            sender: data.sender,
+            payload: data.payload,
+            created: new Date(),
+          };
+          return prevMsg ? [...prevMsg, newMessage] : [newMessage];
+        },
+      );
+      setDmHistory((currHistory) =>
+        currHistory.map((dmInfo) => {
+          if (dmInfo.opponent.nickname === opponent) {
+            return { ...dmInfo, last_dm: new Date(), last_read: new Date() };
+          }
+          return dmInfo;
+        }),
+      );
+    };
+
+    const handleAnnounce = (data: unknown) => {
+      console.log(data);
+    };
+
+    socket.emit('join', { opponent });
+
+    socket.on('subscribe', handleSub);
+    socket.on('subscribe_self', handleSub);
+    socket.on('announcement', handleAnnounce);
+
+    return () => {
+      socket.off('subscribe', handleSub);
+      socket.off('subscribe_self', handleSub);
+      socket.off('announcement', handleAnnounce);
+    };
+  }, [opponent, queryClient, socketRef, setDmHistory]);
+
+  return { socket: socketRef.current };
+}
+
+export function useUpdateDmHistory(opponent: Friend | undefined) {
+  const setDmHistory = useSetRecoilState(dmHistoryState);
+
+  useEffect(() => {
+    if (opponent) {
+      setDmHistory((currHistory) => {
+        const newHistory: DmInfo = {
+          opponent: opponent,
+          last_read: new Date(),
+          last_dm: new Date(),
+        };
+        const idx = currHistory.findIndex(
+          (dmInfo) => dmInfo.opponent.user_id === opponent.user_id,
+        );
+        return idx !== -1
+          ? [
+              ...currHistory.slice(0, idx),
+              newHistory,
+              ...currHistory.slice(idx + 1),
+            ]
+          : [...currHistory, newHistory];
+      });
+    }
+  }, [opponent, setDmHistory]);
+}

--- a/src/hooks/notification.tsx
+++ b/src/hooks/notification.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { toast } from 'react-toastify';
+import { useSocketRef } from '@/hooks/chat';
+
+export function useNotification() {
+  const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:1234`);
+
+  useEffect(() => {
+    const socket = socketRef.current;
+
+    const handleGame = (data: any) => {
+      const toastId = `invite-game-${data.nickname}`;
+      toast.info(
+        <div className="flex justify-between font-pixel text-xs">
+          <p>Play game with {data.nickname}</p>
+          <div className="flex flex-row gap-3">
+            <button
+              className="text-green-500"
+              onClick={() => {
+                console.log('play');
+                toast.dismiss(toastId);
+              }}
+            >
+              O
+            </button>
+            <button
+              className="text-red-500"
+              onClick={() => toast.dismiss(toastId)}
+            >
+              X
+            </button>
+          </div>
+        </div>,
+        {
+          autoClose: false,
+          toastId,
+        },
+      );
+    };
+    const handleChat = (data: unknown) => {
+      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>);
+    };
+    const handleDM = (data: unknown) => {
+      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>);
+    };
+
+    socket.on('notification-game', handleGame);
+    socket.on('notification-chat', handleChat);
+    socket.on('notification-dm', handleDM);
+
+    return () => {
+      socket.off('notification-game', handleGame);
+      socket.off('notification-chat', handleChat);
+      socket.off('notification-dm', handleDM);
+    };
+  }, [socketRef]);
+}

--- a/src/molecule/NotificationChat.tsx
+++ b/src/molecule/NotificationChat.tsx
@@ -1,16 +1,20 @@
-import { RoomInfo } from '@/states/roomInfoState';
-import { ToastContentProps } from 'react-toastify';
+import { useSetRecoilState } from 'recoil';
+import { currentSideBarItemState } from '@/states/currentSideBarItemState';
+import type { ToastContentProps } from 'react-toastify';
+import type { RoomInfo } from '@/states/roomInfoState';
 
 export interface NotificationChatData {
   roomInfo: RoomInfo;
 }
 
-function NotificationGame({
+function NotificationChat({
   data,
   closeToast,
 }: ToastContentProps<NotificationChatData>) {
+  const setCurrentSideBarItem = useSetRecoilState(currentSideBarItemState);
+
   const handleClick = () => {
-    // 채팅 화면으로 이동
+    setCurrentSideBarItem('chat');
     if (closeToast) closeToast();
   };
 
@@ -24,4 +28,4 @@ function NotificationGame({
   );
 }
 
-export default NotificationGame;
+export default NotificationChat;

--- a/src/molecule/NotificationChat.tsx
+++ b/src/molecule/NotificationChat.tsx
@@ -1,0 +1,27 @@
+import { RoomInfo } from '@/states/roomInfoState';
+import { ToastContentProps } from 'react-toastify';
+
+export interface NotificationChatData {
+  roomInfo: RoomInfo;
+}
+
+function NotificationGame({
+  data,
+  closeToast,
+}: ToastContentProps<NotificationChatData>) {
+  const handleClick = () => {
+    // 채팅 화면으로 이동
+    if (closeToast) closeToast();
+  };
+
+  return (
+    <button className="flex items-center justify-between" onClick={handleClick}>
+      <div className="flex flex-col items-start justify-start whitespace-nowrap pr-3">
+        <h2 className="text-sm">Invited to the Chat</h2>
+        <p>{data?.roomInfo.room_name}</p>
+      </div>
+    </button>
+  );
+}
+
+export default NotificationGame;

--- a/src/molecule/NotificationDM.tsx
+++ b/src/molecule/NotificationDM.tsx
@@ -1,4 +1,6 @@
-import { ToastContentProps } from 'react-toastify';
+import { useSetRecoilState } from 'recoil';
+import { currentSideBarItemState } from '@/states/currentSideBarItemState';
+import type { ToastContentProps } from 'react-toastify';
 
 export interface NotificationDMData {
   sender: string;
@@ -9,8 +11,10 @@ function NotificationDM({
   data,
   closeToast,
 }: ToastContentProps<NotificationDMData>) {
+  const setCurrentSideBarItem = useSetRecoilState(currentSideBarItemState);
+
   const handleClick = () => {
-    // DM 화면으로 이동
+    setCurrentSideBarItem('dm');
     if (closeToast) closeToast();
   };
 

--- a/src/molecule/NotificationDM.tsx
+++ b/src/molecule/NotificationDM.tsx
@@ -1,6 +1,6 @@
 import { useSetRecoilState } from 'recoil';
 import { currentSideBarItemState } from '@/states/currentSideBarItemState';
-import { dmHistoryState } from '@/states/dmHistoryState';
+import { currentDMOpponentState } from '@/states/currentDMOpponent';
 import type { ToastContentProps } from 'react-toastify';
 import type { Friend } from '@/hooks/friends';
 
@@ -14,18 +14,12 @@ function NotificationDM({
   closeToast,
 }: ToastContentProps<NotificationDMData>) {
   const setCurrentSideBarItem = useSetRecoilState(currentSideBarItemState);
-  const setDmHistory = useSetRecoilState(dmHistoryState);
+  const setCurrentDMOpponent = useSetRecoilState(currentDMOpponentState);
 
   const handleClick = () => {
     if (data?.sender) {
       setCurrentSideBarItem('dm');
-      setDmHistory((currHistory) =>
-        currHistory.find(
-          (dmInfo) => dmInfo.opponent.user_id === data.sender.user_id,
-        )
-          ? currHistory
-          : [...currHistory, { opponent: data.sender, last_dm: new Date() }],
-      );
+      setCurrentDMOpponent(data.sender.nickname);
     }
     if (closeToast) closeToast();
   };

--- a/src/molecule/NotificationDM.tsx
+++ b/src/molecule/NotificationDM.tsx
@@ -1,9 +1,11 @@
 import { useSetRecoilState } from 'recoil';
 import { currentSideBarItemState } from '@/states/currentSideBarItemState';
+import { dmHistoryState } from '@/states/dmHistoryState';
 import type { ToastContentProps } from 'react-toastify';
+import type { Friend } from '@/hooks/friends';
 
 export interface NotificationDMData {
-  sender: string;
+  sender: Friend;
   payload: string;
 }
 
@@ -12,9 +14,19 @@ function NotificationDM({
   closeToast,
 }: ToastContentProps<NotificationDMData>) {
   const setCurrentSideBarItem = useSetRecoilState(currentSideBarItemState);
+  const setDmHistory = useSetRecoilState(dmHistoryState);
 
   const handleClick = () => {
-    setCurrentSideBarItem('dm');
+    if (data?.sender) {
+      setCurrentSideBarItem('dm');
+      setDmHistory((currHistory) =>
+        currHistory.find(
+          (dmInfo) => dmInfo.opponent.user_id === data.sender.user_id,
+        )
+          ? currHistory
+          : [...currHistory, { opponent: data.sender, last_dm: new Date() }],
+      );
+    }
     if (closeToast) closeToast();
   };
 
@@ -24,7 +36,7 @@ function NotificationDM({
       onClick={handleClick}
     >
       <p>
-        <strong>{data?.sender ?? '???'}</strong>: {data?.payload}
+        <strong>{data?.sender.nickname ?? '???'}</strong>: {data?.payload}
       </p>
     </button>
   );

--- a/src/molecule/NotificationDM.tsx
+++ b/src/molecule/NotificationDM.tsx
@@ -1,0 +1,29 @@
+import { ToastContentProps } from 'react-toastify';
+
+export interface NotificationDMData {
+  sender: string;
+  payload: string;
+}
+
+function NotificationDM({
+  data,
+  closeToast,
+}: ToastContentProps<NotificationDMData>) {
+  const handleClick = () => {
+    // DM 화면으로 이동
+    if (closeToast) closeToast();
+  };
+
+  return (
+    <button
+      className="flex w-full flex-col items-start justify-center whitespace-nowrap"
+      onClick={handleClick}
+    >
+      <p>
+        <strong>{data?.sender ?? '???'}</strong>: {data?.payload}
+      </p>
+    </button>
+  );
+}
+
+export default NotificationDM;

--- a/src/molecule/NotificationGame.tsx
+++ b/src/molecule/NotificationGame.tsx
@@ -1,5 +1,5 @@
 import Button from '@/atom/Button';
-import { ToastContentProps } from 'react-toastify';
+import type { ToastContentProps } from 'react-toastify';
 
 export interface NotificationGameData {
   nickname: string;

--- a/src/molecule/NotificationGame.tsx
+++ b/src/molecule/NotificationGame.tsx
@@ -1,0 +1,32 @@
+import Button from '@/atom/Button';
+import { ToastContentProps } from 'react-toastify';
+
+export interface NotificationGameData {
+  nickname: string;
+  gameId: string;
+}
+
+function NotificationGame({
+  data,
+  closeToast,
+}: ToastContentProps<NotificationGameData>) {
+  return (
+    <div className="flex items-center justify-between">
+      <div className="flex flex-col items-start justify-start whitespace-nowrap pr-3">
+        <h2 className="text-sm">Invited Game</h2>
+        <p>{data?.nickname}</p>
+      </div>
+      <Button
+        className="break-keep bg-green-500 text-xs"
+        onClick={() => {
+          console.log(data?.gameId);
+          if (closeToast) closeToast();
+        }}
+      >
+        Play
+      </Button>
+    </div>
+  );
+}
+
+export default NotificationGame;

--- a/src/organism/Directmsg.tsx
+++ b/src/organism/Directmsg.tsx
@@ -1,14 +1,8 @@
-import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { fetcher } from '@/hooks/fetcher';
+import { useRecoilState } from 'recoil';
 import { currentDMOpponentState } from '@/states/currentDMOpponent';
-import { sortedDmHistoryState } from '@/states/dmHistoryState';
-import SideBarHeader from '@/molecule/SideBarHeader';
 import SideBarLayout from '@/molecule/SideBarLayout';
 import DirectmsgRoom from './DirectmsgRoom';
-import StatusIndicator from '@/molecule/StatusIndicator';
-import type { Friend } from '@/hooks/friends';
+import DirectmsgList from './DirectmsgList';
 
 const Directmsg = () => {
   const [currentDMOpponent, setCurrentDMOpponent] = useRecoilState(
@@ -28,92 +22,5 @@ const Directmsg = () => {
     </SideBarLayout>
   );
 };
-
-function useSearchUser(nickname: string) {
-  const setCurrentDMOpponent = useSetRecoilState(currentDMOpponentState);
-
-  const data = useQuery<Friend>({
-    queryKey: ['user', nickname],
-    queryFn: async () => {
-      const res = await fetcher(`/user/${nickname}`);
-      if (res.ok) return res.json();
-      throw res;
-    },
-    onSuccess: () => {
-      setCurrentDMOpponent(nickname);
-    },
-    enabled: !!nickname,
-    retry: false,
-    refetchOnWindowFocus: false,
-  });
-  return data;
-}
-
-function DirectmsgList() {
-  const [nickname, setNickname] = useState('');
-  const [query, setQuery] = useState('');
-  const { isFetching, isError } = useSearchUser(query);
-
-  const setCurrentDMOpponent = useSetRecoilState(currentDMOpponentState);
-  const dmHistory = useRecoilValue(sortedDmHistoryState);
-
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    if (nickname) {
-      setQuery(nickname);
-    }
-  };
-
-  return (
-    <>
-      <SideBarHeader>Direct Message</SideBarHeader>
-      <form
-        onSubmit={handleSubmit}
-        className="flex w-full flex-row items-center gap-2 bg-neutral-800 p-3"
-      >
-        <label htmlFor="nickname">To.</label>
-        <input
-          className="w-full bg-neutral-700 p-1 disabled:opacity-20"
-          name="nickname"
-          type="search"
-          value={nickname}
-          onChange={(e) => setNickname(e.target.value)}
-          disabled={isFetching}
-          required
-        />
-        <button
-          className="disabled:opacity-20"
-          type="submit"
-          disabled={isFetching}
-        >
-          Q
-        </button>
-      </form>
-      {isError ? (
-        <div className="flex w-full items-center justify-center text-xs text-red-500">
-          <p>Not Found</p>
-        </div>
-      ) : null}
-      <ul className="w-full border-t border-neutral-400">
-        {dmHistory.map((dmInfo) => (
-          <li key={dmInfo.opponent.user_id} className="w-full bg-neutral-700">
-            <button
-              className="flex w-full flex-col gap-1 border-b border-neutral-400 p-3 px-5"
-              onClick={() => setCurrentDMOpponent(dmInfo.opponent.nickname)}
-            >
-              <p>{dmInfo.opponent.nickname}</p>
-              <div className="flex flex-row items-center space-x-2">
-                <StatusIndicator status={dmInfo.opponent.status} />
-                <p className="min-w-0 truncate text-xs">
-                  {dmInfo.opponent.status ?? 'unknown'}
-                </p>
-              </div>
-            </button>
-          </li>
-        ))}
-      </ul>
-    </>
-  );
-}
 
 export default Directmsg;

--- a/src/organism/DirectmsgList.tsx
+++ b/src/organism/DirectmsgList.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { fetcher } from '@/hooks/fetcher';
+import { sortedDmHistoryState } from '@/states/dmHistoryState';
+import { currentDMOpponentState } from '@/states/currentDMOpponent';
+import SideBarHeader from '@/molecule/SideBarHeader';
+import StatusIndicator from '@/molecule/StatusIndicator';
+import type { Friend } from '@/hooks/friends';
+
+function DirectmsgList() {
+  const setCurrentDMOpponent = useSetRecoilState(currentDMOpponentState);
+  const dmHistory = useRecoilValue(sortedDmHistoryState);
+
+  return (
+    <>
+      <SideBarHeader>Direct Message</SideBarHeader>
+      <AddDirectmsgForm />
+      <ul className="w-full border-t border-neutral-400">
+        {dmHistory.map((dmInfo) => (
+          <li key={dmInfo.opponent.user_id} className="w-full bg-neutral-700">
+            <button
+              className="flex w-full flex-col gap-1 border-b border-neutral-400 p-3 px-5"
+              onClick={() => setCurrentDMOpponent(dmInfo.opponent.nickname)}
+            >
+              <p>{dmInfo.opponent.nickname}</p>
+              <div className="flex flex-row items-center space-x-2">
+                <StatusIndicator status={dmInfo.opponent.status} />
+                <p className="min-w-0 truncate text-xs">
+                  {dmInfo.opponent.status ?? 'unknown'}
+                </p>
+              </div>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function useSearchUser(nickname: string) {
+  const setCurrentDMOpponent = useSetRecoilState(currentDMOpponentState);
+
+  const data = useQuery<Friend>({
+    queryKey: ['user', nickname],
+    queryFn: async () => {
+      const res = await fetcher(`/user/${nickname}`);
+      if (res.ok) return res.json();
+      throw res;
+    },
+    onSuccess: () => {
+      setCurrentDMOpponent(nickname);
+    },
+    enabled: !!nickname,
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+  return data;
+}
+
+function AddDirectmsgForm() {
+  const [nickname, setNickname] = useState('');
+  const [query, setQuery] = useState('');
+  const { isFetching, isError } = useSearchUser(query);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (nickname) {
+      setQuery(nickname);
+    }
+  };
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit}
+        className="flex w-full flex-row items-center gap-2 bg-neutral-800 p-3"
+      >
+        <label htmlFor="nickname">To.</label>
+        <input
+          className="w-full bg-neutral-700 p-1 disabled:opacity-20"
+          name="nickname"
+          type="search"
+          value={nickname}
+          onChange={(e) => setNickname(e.target.value)}
+          disabled={isFetching}
+          required
+        />
+        <button
+          className="disabled:opacity-20"
+          type="submit"
+          disabled={isFetching}
+        >
+          Q
+        </button>
+      </form>
+      {isError ? (
+        <div className="flex w-full items-center justify-center bg-neutral-800 pb-2 text-xs text-red-500">
+          <p>Not Found</p>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+export default DirectmsgList;

--- a/src/organism/DirectmsgRoom.tsx
+++ b/src/organism/DirectmsgRoom.tsx
@@ -1,95 +1,18 @@
-import { useEffect, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useAutoScroll, useSocketRef } from '@/hooks/chat';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useAutoScroll } from '@/hooks/chat';
 import { fetcher } from '@/hooks/fetcher';
-import StatusIndicator from '@/molecule/StatusIndicator';
-import { dmHistoryState, type DmInfo } from '@/states/dmHistoryState';
 import { type Friend } from '@/hooks/friends';
+import {
+  useDirectMessages,
+  useDirectMessageSocket,
+  useUpdateDmHistory,
+} from '@/hooks/dm';
+import StatusIndicator from '@/molecule/StatusIndicator';
 
 interface DirectmsgRoomProps {
   opponent: string;
   close(): void;
-}
-
-interface Message {
-  sender: Friend;
-  payload: string;
-  created: Date;
-}
-
-interface SubscribeData {
-  sender: Friend;
-  payload: string;
-}
-
-function useDirectMessages(opponent: string) {
-  const data = useQuery<Message[]>({
-    queryKey: ['dm/messages', opponent],
-    queryFn: async () => {
-      const res = await fetcher(`/dm/${opponent}/messages`);
-
-      if (res.ok) {
-        const data = await res.json();
-        return data.messages;
-      }
-      return [];
-    },
-    refetchOnWindowFocus: false,
-  });
-
-  return data;
-}
-
-function useDirectMessage(opponent: string) {
-  const queryClient = useQueryClient();
-  const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:9992`);
-  const { data: messages } = useDirectMessages(opponent);
-  const setDmHistory = useSetRecoilState(dmHistoryState);
-
-  useEffect(() => {
-    const socket = socketRef.current;
-
-    const handleSub = (data: SubscribeData) => {
-      queryClient.setQueryData<Message[]>(
-        ['dm/messages', opponent],
-        (prevMsg) => {
-          const newMessage: Message = {
-            sender: data.sender,
-            payload: data.payload,
-            created: new Date(),
-          };
-          return prevMsg ? [...prevMsg, newMessage] : [newMessage];
-        },
-      );
-      setDmHistory((currHistory) =>
-        currHistory.map((dmInfo) => {
-          if (dmInfo.opponent.nickname === opponent) {
-            return { ...dmInfo, last_dm: new Date(), last_read: new Date() };
-          }
-          return dmInfo;
-        }),
-      );
-    };
-
-    const handleAnnounce = (data: unknown) => {
-      console.log(data);
-    };
-
-    socket.emit('join', { opponent });
-
-    socket.on('subscribe', handleSub);
-    socket.on('subscribe_self', handleSub);
-    socket.on('announcement', handleAnnounce);
-
-    return () => {
-      socket.off('subscribe', handleSub);
-      socket.off('subscribe_self', handleSub);
-      socket.off('announcement', handleAnnounce);
-    };
-  }, [opponent, queryClient, socketRef, setDmHistory]);
-
-  return { messages, socket: socketRef.current };
 }
 
 function useOpponent(nickname: string) {
@@ -105,107 +28,118 @@ function useOpponent(nickname: string) {
 }
 
 function DirectmsgRoom({ opponent, close }: DirectmsgRoomProps) {
-  const [content, setContent] = useState('');
-  const { messages, socket } = useDirectMessage(opponent);
+  const { socket } = useDirectMessageSocket(opponent);
   const { data: opponentInfo } = useOpponent(opponent);
-  const autoScrollRef = useAutoScroll(messages);
+  useUpdateDmHistory(opponentInfo);
 
-  const setDmHistory = useSetRecoilState(dmHistoryState);
-  useEffect(() => {
-    if (opponentInfo) {
-      setDmHistory((currHistory) => {
-        const newHistory: DmInfo = {
-          opponent: opponentInfo,
-          last_read: new Date(),
-          last_dm: new Date(),
-        };
-        const idx = currHistory.findIndex(
-          (dmInfo) => dmInfo.opponent.user_id === opponentInfo.user_id,
-        );
-        return idx !== -1
-          ? [
-              ...currHistory.slice(0, idx),
-              newHistory,
-              ...currHistory.slice(idx + 1),
-            ]
-          : [...currHistory, newHistory];
-      });
+  const handleSubmit = (content: string) => {
+    content = content.trim();
+    if (content) {
+      socket.emit('publish', { opponent, payload: content });
     }
-  }, [opponentInfo, setDmHistory]);
-
-  const sendMessage = () => {
-    const msg = content.trim();
-    if (msg) {
-      socket.emit('publish', { opponent, payload: msg });
-    }
-    setContent('');
   };
 
   return (
     <>
       <div className="flex h-fit w-full items-center justify-between border-b border-inherit bg-neutral-800 p-2">
-        {opponentInfo ? (
-          <div className="flex flex-row gap-2 p-2">
-            <div className="m-1 flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
-              <img
-                src={opponentInfo.prof_img}
-                alt="profile"
-                className="h-full w-full object-cover"
-              />
-            </div>
-            <div className="flex flex-col">
-              <p>{opponentInfo.nickname}</p>
-              <div className="flex flex-row items-center space-x-2">
-                <StatusIndicator status={opponentInfo.status} />
-                <p className="min-w-0 truncate text-xs">
-                  {opponentInfo.status ?? 'unknown'}
-                </p>
-              </div>
-            </div>
-            <button className="px-3">:</button>
-          </div>
-        ) : (
-          opponent
-        )}
+        {opponentInfo ? <OpponentProfile opponent={opponentInfo} /> : opponent}
         <button onClick={close} className="px-1">
           ⬅
         </button>
       </div>
-      <div
-        ref={autoScrollRef}
-        className="h-full w-full grow overflow-y-auto border-b border-inherit"
-      >
-        <ul className="flex h-fit w-full flex-col items-start justify-start">
-          {messages?.map((message, idx) => (
-            <li
-              key={idx}
-              className="h-fit w-full break-words p-1 px-5 text-xs"
-            >{`${message.sender.nickname}: ${message.payload}`}</li>
-          ))}
-        </ul>
-      </div>
-      <div className="h-30 flex">
-        <textarea
-          placeholder="plase input here."
-          className="h-20 w-full resize-none border-none bg-neutral-300 text-black"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          onKeyUp={(e) => {
-            if (e.key === 'Enter') {
-              sendMessage();
-            }
-          }}
-        />
-        <button
-          className="h-full border-b border-inherit bg-neutral-800 px-3"
-          onClick={() => {
-            sendMessage();
-          }}
-        >
-          send
-        </button>
-      </div>
+      <MessageContainer opponent={opponent} />
+      <TextInput onSubmit={handleSubmit} />
     </>
+  );
+}
+
+interface OpponentProfileProps {
+  opponent: Friend;
+}
+
+function OpponentProfile({ opponent }: OpponentProfileProps) {
+  return (
+    <div className="flex flex-row gap-2 p-2">
+      <div className="m-1 flex h-10 w-10 items-center justify-center overflow-hidden rounded-full">
+        <img
+          src={opponent.prof_img}
+          alt="profile"
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <div className="flex flex-col">
+        <p>{opponent.nickname}</p>
+        <div className="flex flex-row items-center space-x-2">
+          <StatusIndicator status={opponent.status} />
+          <p className="min-w-0 truncate text-xs">
+            {opponent.status ?? 'unknown'}
+          </p>
+        </div>
+      </div>
+      <button className="px-3">:</button>
+    </div>
+  );
+}
+
+interface MessageContainerProps {
+  opponent: string;
+}
+
+function MessageContainer({ opponent }: MessageContainerProps) {
+  const { data: messages } = useDirectMessages(opponent);
+  const autoScrollRef = useAutoScroll(messages);
+
+  return (
+    <div
+      ref={autoScrollRef}
+      className="h-full w-full grow overflow-y-auto border-b border-inherit"
+    >
+      <ul className="flex h-fit w-full flex-col items-start justify-start">
+        {messages?.map((message, idx) => (
+          <li
+            key={idx}
+            className="h-fit w-full break-words p-1 px-5 text-xs"
+          >{`${message.sender.nickname}: ${message.payload}`}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface TextInputProps {
+  onSubmit(content: string): void;
+}
+
+function TextInput({ onSubmit }: TextInputProps) {
+  const [content, setContent] = useState('');
+
+  const sendMessage = () => {
+    onSubmit(content);
+    setContent('');
+  };
+
+  return (
+    <div className="h-30 flex">
+      <textarea
+        placeholder="plase input here."
+        className="h-20 w-full resize-none border-none bg-neutral-300 text-black"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyUp={(e) => {
+          if (e.key === 'Enter') {
+            sendMessage();
+          }
+        }}
+      />
+      <button
+        className="h-full border-b border-inherit bg-neutral-800 px-3"
+        onClick={() => {
+          sendMessage();
+        }}
+      >
+        send
+      </button>
+    </div>
   );
 }
 

--- a/src/organism/FriendsList.tsx
+++ b/src/organism/FriendsList.tsx
@@ -13,19 +13,19 @@ import { useSocketRef } from '@/hooks/chat';
 
 function useFriendsStatusSocket() {
   const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:9994`);
-  const { setQueryData } = useQueryClient();
+  const queryClient = useQueryClient();
 
   useEffect(() => {
     const handleNoti = (data: {
-      userId: string;
-      status: 'online' | 'offline' | 'ingame';
+      user: string;
+      state: 'online' | 'offline' | 'ingame';
     }) => {
       console.log(data);
-      setQueryData(['friends/all'], (prevFriends?: Friend[]) => {
+      queryClient.setQueryData(['friend/all'], (prevFriends?: Friend[]) => {
         return prevFriends
           ? prevFriends.map((friend) =>
-              friend.user_id === data.userId
-                ? { ...friend, status: data.status }
+              friend.user_id === data.user
+                ? { ...friend, status: data.state }
                 : friend,
             )
           : undefined;
@@ -39,7 +39,7 @@ function useFriendsStatusSocket() {
     return () => {
       socket.off('update', handleNoti);
     };
-  }, [setQueryData, socketRef]);
+  }, [socketRef]);
 }
 
 function FriendsList() {

--- a/src/organism/FriendsList.tsx
+++ b/src/organism/FriendsList.tsx
@@ -34,10 +34,10 @@ function useFriendsStatusSocket() {
 
     const socket = socketRef.current;
 
-    socket.on('subscribe', handleNoti);
+    socket.on('update', handleNoti);
 
     return () => {
-      socket.off('subscribe', handleNoti);
+      socket.off('update', handleNoti);
     };
   }, [setQueryData, socketRef]);
 }

--- a/src/organism/Nav.tsx
+++ b/src/organism/Nav.tsx
@@ -1,16 +1,16 @@
+import { useRecoilState } from 'recoil';
+import { currentSideBarItemState } from '@/states/currentSideBarItemState';
 import DmIcon from '@/atom/DmIcon';
 import ChatIcon from '@/atom/ChatIcon';
 import FriendIcon from '@/atom/FriendIcon';
-import { SidebarItem } from '@/pages/Main';
 import CurrentUserWidget from '@/molecule/CurrentUserWidget';
 import SearchUserProfileForm from './SearchUserProfileForm';
 
-interface NavProps {
-  current: string;
-  onChange(n: SidebarItem): void;
-}
+const Nav = () => {
+  const [currentSideBarItem, setCurrentSideBarItem] = useRecoilState(
+    currentSideBarItemState,
+  );
 
-const Nav = ({ current, onChange }: NavProps) => {
   return (
     <div
       className="flex h-[78px] w-full items-center justify-between
@@ -21,18 +21,18 @@ const Nav = ({ current, onChange }: NavProps) => {
       <div className="flex items-center gap-2">
         <SearchUserProfileForm />
         <div className="">
-          <button onClick={() => onChange('chat')}>
-            <ChatIcon isActive={current === 'chat'} />
+          <button onClick={() => setCurrentSideBarItem('chat')}>
+            <ChatIcon isActive={currentSideBarItem === 'chat'} />
           </button>
         </div>
         <div className="">
-          <button onClick={() => onChange('friend')}>
-            <FriendIcon isActive={current === 'friend'} />
+          <button onClick={() => setCurrentSideBarItem('friend')}>
+            <FriendIcon isActive={currentSideBarItem === 'friend'} />
           </button>
         </div>
         <div className="">
-          <button onClick={() => onChange('dm')}>
-            <DmIcon isActive={current === 'dm'} />
+          <button onClick={() => setCurrentSideBarItem('dm')}>
+            <DmIcon isActive={currentSideBarItem === 'dm'} />
           </button>
         </div>
       </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -71,8 +71,7 @@ function useLogin() {
 
   useEffect(() => {
     if (error) {
-      console.log(error);
-      toast.error(<div className="font-pixel text-xs">{error}</div>);
+      toast.error(error);
       navigate('/', { replace: true });
     }
   }, [error, navigate]);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import { useSetRecoilState } from 'recoil';
 import { useMutation } from '@tanstack/react-query';
 import { fetcher } from '@/hooks/fetcher';
 import { SignUpUserInfo, signUpUserInfoState } from '@/states/user/signUp';
+import { toast } from 'react-toastify';
 
 interface LoginParams {
   provider: string;
@@ -62,7 +63,6 @@ function useLogin() {
     mutate({ provider, code });
   }, [params, mutate]);
 
-  // FIX: error 메시지를 recoil을 통해 이동한 페이지에서 보여주기
   useEffect(() => {
     if (isError) {
       setError('login request failed');
@@ -72,6 +72,7 @@ function useLogin() {
   useEffect(() => {
     if (error) {
       console.log(error);
+      toast.error(<div className="font-pixel text-xs">{error}</div>);
       navigate('/', { replace: true });
     }
   }, [error, navigate]);

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,36 +1,76 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useSocketRef } from '@/hooks/chat';
 
-import Nav from "@/organism/Nav";
-import Chat from "@/organism/Chat";
-import Friends from "@/organism/Friends";
-import Directmsg from "@/organism/Directmsg";
+import Nav from '@/organism/Nav';
+import Chat from '@/organism/Chat';
+import Friends from '@/organism/Friends';
+import Directmsg from '@/organism/Directmsg';
 import UserProfileModal from '@/organism/UserProfileModal';
-import GameContainer from "../templates/GameContainer";
+import GameContainer from '../templates/GameContainer';
+import { toast, ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.min.css';
 
 export type SidebarItem = 'dm' | 'friend' | 'chat';
 
 function sidebarSelector(sidebarIndex: SidebarItem) {
-	return sidebarIndex === 'dm' ? (
-		<Directmsg />
-	) : sidebarIndex === 'friend' ? (
-		<Friends />
-	) : (
-		<Chat />
-	);
+  return sidebarIndex === 'dm' ? (
+    <Directmsg />
+  ) : sidebarIndex === 'friend' ? (
+    <Friends />
+  ) : (
+    <Chat />
+  );
+}
+
+function useNotification() {
+  const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:1234`);
+
+  useEffect(() => {
+    const socket = socketRef.current;
+
+    const handleGame = (data: unknown) => {
+      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>, {
+        autoClose: false,
+      });
+    };
+    const handleChat = (data: unknown) => {
+      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>);
+    };
+    const handleDM = (data: unknown) => {
+      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>);
+    };
+
+    socket.on('notification-game', handleGame);
+    socket.on('notification-chat', handleChat);
+    socket.on('notification-dm', handleDM);
+
+    return () => {
+      socket.off('notification-game', handleGame);
+      socket.off('notification-chat', handleChat);
+      socket.off('notification-dm', handleDM);
+    };
+  }, [socketRef]);
 }
 
 function Main() {
-	const [sideState, setSideState] = useState<SidebarItem>("chat");
+  const [sideState, setSideState] = useState<SidebarItem>('chat');
+  useNotification();
 
-	return (
-		<div className="bg-neutral-600 flex flex-col w-full h-full mx-auto my-0">
-			<Nav current={sideState} onChange={setSideState}></Nav>
-			<div className="flex h-full w-full min-h-0">
-				<GameContainer />
-				{sidebarSelector(sideState)}
-			</div>
+  return (
+    <div className="mx-auto my-0 flex h-full w-full flex-col bg-neutral-600">
+      <Nav current={sideState} onChange={setSideState}></Nav>
+      <div className="flex h-full min-h-0 w-full">
+        <GameContainer />
+        {sidebarSelector(sideState)}
+      </div>
       <UserProfileModal />
-		</div>
+      <ToastContainer
+        position="top-center"
+        theme="dark"
+        closeOnClick={false}
+        closeButton={true}
+      />
+    </div>
   );
 }
 

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -7,7 +7,7 @@ import Friends from '@/organism/Friends';
 import Directmsg from '@/organism/Directmsg';
 import UserProfileModal from '@/organism/UserProfileModal';
 import GameContainer from '../templates/GameContainer';
-import { toast, ToastContainer } from 'react-toastify';
+import { toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.min.css';
 
 export type SidebarItem = 'dm' | 'friend' | 'chat';
@@ -64,12 +64,6 @@ function Main() {
         {sidebarSelector(sideState)}
       </div>
       <UserProfileModal />
-      <ToastContainer
-        position="top-center"
-        theme="dark"
-        closeOnClick={false}
-        closeButton={true}
-      />
     </div>
   );
 }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { useNotification } from '@/hooks/notification';
 
 import Nav from '@/organism/Nav';
@@ -7,13 +6,15 @@ import Friends from '@/organism/Friends';
 import Directmsg from '@/organism/Directmsg';
 import UserProfileModal from '@/organism/UserProfileModal';
 import GameContainer from '../templates/GameContainer';
+import { useRecoilValue } from 'recoil';
+import { currentSideBarItemState } from '@/states/currentSideBarItemState';
 
-export type SidebarItem = 'dm' | 'friend' | 'chat';
+function SidebarSelector() {
+  const currentSideBarItem = useRecoilValue(currentSideBarItemState);
 
-function sidebarSelector(sidebarIndex: SidebarItem) {
-  return sidebarIndex === 'dm' ? (
+  return currentSideBarItem === 'dm' ? (
     <Directmsg />
-  ) : sidebarIndex === 'friend' ? (
+  ) : currentSideBarItem === 'friend' ? (
     <Friends />
   ) : (
     <Chat />
@@ -21,15 +22,14 @@ function sidebarSelector(sidebarIndex: SidebarItem) {
 }
 
 function Main() {
-  const [sideState, setSideState] = useState<SidebarItem>('chat');
   useNotification();
 
   return (
     <div className="mx-auto my-0 flex h-full w-full flex-col bg-neutral-600">
-      <Nav current={sideState} onChange={setSideState}></Nav>
+      <Nav />
       <div className="flex h-full min-h-0 w-full">
         <GameContainer />
-        {sidebarSelector(sideState)}
+        <SidebarSelector />
       </div>
       <UserProfileModal />
     </div>

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useSocketRef } from '@/hooks/chat';
+import { useState } from 'react';
+import { useNotification } from '@/hooks/notification';
 
 import Nav from '@/organism/Nav';
 import Chat from '@/organism/Chat';
@@ -7,8 +7,6 @@ import Friends from '@/organism/Friends';
 import Directmsg from '@/organism/Directmsg';
 import UserProfileModal from '@/organism/UserProfileModal';
 import GameContainer from '../templates/GameContainer';
-import { toast } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.min.css';
 
 export type SidebarItem = 'dm' | 'friend' | 'chat';
 
@@ -20,36 +18,6 @@ function sidebarSelector(sidebarIndex: SidebarItem) {
   ) : (
     <Chat />
   );
-}
-
-function useNotification() {
-  const socketRef = useSocketRef(`ws://${import.meta.env.VITE_BASE_URL}:1234`);
-
-  useEffect(() => {
-    const socket = socketRef.current;
-
-    const handleGame = (data: unknown) => {
-      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>, {
-        autoClose: false,
-      });
-    };
-    const handleChat = (data: unknown) => {
-      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>);
-    };
-    const handleDM = (data: unknown) => {
-      toast(<div className="font-pixel text-xs">{JSON.stringify(data)}</div>);
-    };
-
-    socket.on('notification-game', handleGame);
-    socket.on('notification-chat', handleChat);
-    socket.on('notification-dm', handleDM);
-
-    return () => {
-      socket.off('notification-game', handleGame);
-      socket.off('notification-chat', handleChat);
-      socket.off('notification-dm', handleDM);
-    };
-  }, [socketRef]);
 }
 
 function Main() {

--- a/src/states/currentSideBarItemState.ts
+++ b/src/states/currentSideBarItemState.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+export type SideBarItem = 'chat' | 'friend' | 'dm';
+
+export const currentSideBarItemState = atom<SideBarItem>({
+  key: 'currentSideBarItem',
+  default: 'friend',
+});

--- a/src/states/dmHistoryState.ts
+++ b/src/states/dmHistoryState.ts
@@ -1,0 +1,23 @@
+import { atom, selector } from 'recoil';
+import type { Friend } from '@/hooks/friends';
+
+export interface DmInfo {
+  opponent: Friend;
+  last_dm: Date;
+  last_read?: Date | undefined;
+}
+
+export const dmHistoryState = atom<DmInfo[]>({
+  key: 'dmHistory',
+  default: [],
+});
+
+export const sortedDmHistoryState = selector<DmInfo[]>({
+  key: 'sortedDmHistory',
+  get: ({ get }) => {
+    const dmHistory = get(dmHistoryState);
+    return dmHistory
+      .slice()
+      .sort((a, b) => b.last_dm.getTime() - a.last_dm.getTime());
+  },
+});


### PR DESCRIPTION
# Abstract

- 이제 어디서든 알림창을 띄울 수 있습니다.
이벤트 핸들러나 useEffect 훅에서 사용할 수 있습니다.

```typescript
import { toast } from 'react-toastify';

// 간단한 텍스트부터
toast('hello world');

// info, warning, error도 있습니다
toast.error(errorMsg);

// 그리고 컴포넌트도 가능합니다
// 단 아래 코드와 같은 방식으로는 state와 props를 활용할 수 없습니다
// 자세한건 https://fkhadra.github.io/react-toastify/render-what-you-want
toast(<div>hello</div>);

```

- 알림 소켓을 통해 받는 game, chat, dm에 관한 메시지 핸들러를 작성했습니다. 백엔드로부터 받는 데이터는 임시로 작성되었고 각각 컴포넌트로 분리해봤어요.
- 최근 dm 목록을 화면에 보여줍니다. 단 리스트는 메모리에 저장되며 매 접속마다 초기화됩니다. 필요하다면 로컬스토리지로 옮길 수 있습니다.

close #53 

## Types of edition

- [x] New feature (not modifying existing features)

# Test results

- [x] Compile succeed