### PR TITLE
Change refresh logic to react-query

### DIFF
--- a/src/hooks/chat.ts
+++ b/src/hooks/chat.ts
@@ -1,15 +1,62 @@
-import { useEffect, useRef } from "react";
-import { io } from "socket.io-client";
+import { useEffect, useRef } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { io } from 'socket.io-client';
+import { accessTokenState } from '@/states/user/auth';
+import { RoomInfo, roomInfoState } from '@/states/roomInfoState';
+import { useFetcher } from '@/hooks/fetcher';
 
+export type RoomListType = 'all' | 'joined';
+
+export function useRoomList(type: RoomListType) {
+  const fetcher = useFetcher();
+  const result = useQuery({
+    queryKey: ['chat/rooms', type],
+    queryFn: async (): Promise<RoomInfo[]> => {
+      const res = await fetcher(`/chat/rooms/${type}`);
+      if (res.ok) {
+        const data = await res.json();
+        return data.rooms;
+      }
+      return [];
+    },
+  });
+  return result;
+}
+
+export function useJoinRoom() {
+  const fetcher = useFetcher();
+  const setRoomInfo = useSetRecoilState(roomInfoState);
+  const mutation = useMutation({
+    mutationFn: async (room: RoomInfo) => {
+      return fetcher(`/chat/room/${room.room_id}/join`, {
+        method: 'POST',
+        body: JSON.stringify({ room_password: '' }),
+      });
+    },
+    onSuccess: (data, variables) => {
+      if (data.ok) {
+        setRoomInfo(variables ?? null);
+      }
+    },
+  });
+  return mutation;
+}
 
 export function useSocketRef(url: string) {
-  const access_token = window.localStorage.getItem('access_token');
+  const access_token = useRecoilValue(accessTokenState);
   const socketRef = useRef(
     io(url, {
       auth: { access_token },
       autoConnect: false,
     }),
   );
+
+  useEffect(() => {
+    if (access_token) {
+      socketRef.current.auth = { access_token };
+    }
+  }, [access_token]);
 
   useEffect(() => {
     const socket = socketRef.current;

--- a/src/hooks/dm.ts
+++ b/src/hooks/dm.ts
@@ -3,7 +3,7 @@ import { useSetRecoilState } from "recoil";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { dmHistoryState, type DmInfo } from '@/states/dmHistoryState';
 import { useSocketRef } from "./chat";
-import { fetcher } from "./fetcher";
+import { useFetcher } from "./fetcher";
 import { type Friend } from "./friends";
 
 interface Message {
@@ -18,6 +18,7 @@ interface SubscribeData {
 }
 
 export function useDirectMessages(opponent: string) {
+  const fetcher = useFetcher();
   const data = useQuery<Message[]>({
     queryKey: ['dm/messages', opponent],
     queryFn: async () => {

--- a/src/hooks/friends.ts
+++ b/src/hooks/friends.ts
@@ -1,5 +1,7 @@
+import { accessTokenState } from '@/states/user/auth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetcher } from './fetcher';
+import { useRecoilValue } from 'recoil';
+import { useFetcher } from './fetcher';
 
 export interface Friend {
   user_id: string;
@@ -12,6 +14,9 @@ export interface Friend {
 }
 
 export function useFriends() {
+  const fetcher = useFetcher();
+  const accessToken = useRecoilValue(accessTokenState);
+
   const { data, error, isLoading, isError } = useQuery({
     queryKey: ['friend/all'],
     queryFn: async (): Promise<Friend[]> => {
@@ -29,11 +34,13 @@ export function useFriends() {
         list: friends.filter((friend) => friend.status === 'offline'),
       },
     ],
+    enabled: !!accessToken,
   });
   return { friends: data, error, isLoading, isError };
 }
 
 export function useDeleteFriend() {
+  const fetcher = useFetcher();
   const queryClient = useQueryClient();
   const deleteMutation = useMutation({
     mutationFn: (friend: Friend) => {
@@ -56,6 +63,7 @@ export interface RequestedFriend {
 }
 
 export function useRequestedFriends(type: 'sent' | 'recv') {
+  const fetcher = useFetcher();
   const data = useQuery({
     queryKey: ['friend/request', type],
     queryFn: async (): Promise<RequestedFriend[]> => {

--- a/src/hooks/matchHistory.ts
+++ b/src/hooks/matchHistory.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetcher } from './fetcher';
+import { useFetcher } from './fetcher';
 
 export interface HistoryUser {
   user_id: string;
@@ -20,6 +20,7 @@ export interface MatchHistory {
 }
 
 export function useMatchHistory(nickname: string) {
+  const fetcher = useFetcher();
   const data = useQuery<MatchHistory[]>({
     queryKey: ['matchHistory', nickname],
     queryFn: async () => {

--- a/src/hooks/profileModal.ts
+++ b/src/hooks/profileModal.ts
@@ -7,8 +7,8 @@ import {
   useInteractions,
 } from '@floating-ui/react-dom-interactions';
 import { useQuery } from '@tanstack/react-query';
-import { fetcher } from './fetcher';
-import { UserInfo } from './user';
+import { useFetcher } from './fetcher';
+import { UserInfo } from '@/states/user/auth';
 
 export function useProfileModal() {
   const [profileUser, setProfileUser] = useRecoilState(profileUserState);
@@ -39,6 +39,7 @@ export function useProfileModal() {
 }
 
 export function useUserInfo(nickname: string) {
+  const fetcher = useFetcher();
   const data = useQuery<UserInfo>({
     queryKey: ['user', nickname],
     queryFn: async () => {

--- a/src/hooks/user.ts
+++ b/src/hooks/user.ts
@@ -1,23 +1,60 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetcher } from '@/hooks/fetcher';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { refreshAccessToken, useFetcher } from '@/hooks/fetcher';
 import { useNavigate } from 'react-router-dom';
+import { accessTokenState, UserInfo } from '@/states/user/auth';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { toast } from 'react-toastify';
 
-export interface UserInfo {
-  user_id: string;
-  nickname: string;
-  provider: string;
-  third_party_id: string;
-  prof_img: string;
-  mmr: number;
-  two_factor_authentication_type?: string;
-  two_factor_authentication_key?: string;
-  created: Date;
-  deleted?: Date;
+interface RefreshData {
+  access_token: string;
+  refresh_token: string;
+}
+
+export function useRefreshToken() {
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+
+  useQuery<RefreshData>({
+    queryKey: ['auth/refresh'],
+    queryFn: async () => {
+      const res = await refreshAccessToken();
+
+      if (res?.ok) return res.json();
+      throw res;
+    },
+    onSuccess: (data) => {
+      if (data.access_token) {
+        setAccessToken(data.access_token);
+        window.localStorage.setItem('refresh_token', data.refresh_token);
+        queryClient.invalidateQueries({
+          predicate: (query) => query.queryKey[0] !== 'auth/refresh',
+        });
+      } else {
+        throw data;
+      }
+    },
+    onError: (err) => {
+      if (err instanceof Response) {
+        if (err.status === 401) {
+          toast.error('session is expired');
+          navigate('/');
+        }
+      }
+    },
+    enabled: !accessToken,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    refetchInterval: 3500 * 1000,
+  });
+
+  return accessToken;
 }
 
 export function useCurrentUser() {
+  const fetcher = useFetcher();
   const data = useQuery<UserInfo>({
-    queryKey: ['/user'],
+    queryKey: ['user'],
     queryFn: async () => {
       const res = await fetcher('/user');
 
@@ -30,9 +67,10 @@ export function useCurrentUser() {
 
 export function useLogOut() {
   const navigate = useNavigate();
+  const setAccessToken = useSetRecoilState(accessTokenState);
 
   const logOut = () => {
-    window.localStorage.removeItem('access_token');
+    setAccessToken(null);
     window.localStorage.removeItem('refresh_token');
     navigate('/');
   };

--- a/src/molecule/CurrentUserWidget.tsx
+++ b/src/molecule/CurrentUserWidget.tsx
@@ -1,11 +1,13 @@
-import { useCurrentUser, useLogOut, UserInfo } from '@/hooks/user';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useLogOut } from '@/hooks/user';
 import { useOptionMenu } from '@/hooks/optionMenu';
-import OptionMenu, { Option } from '@/molecule/OptionMenu';
-import { useSetRecoilState } from 'recoil';
 import { profileUserState } from '@/states/user/profileUser';
+import { currentUserInfoState, UserInfo } from '@/states/user/auth';
+import OptionMenu, { Option } from '@/molecule/OptionMenu';
+import Button from '@/atom/Button';
 
 function CurrentUserWidget() {
-  const { data, isLoading, isError } = useCurrentUser();
+  const data = useRecoilValue(currentUserInfoState);
   const {
     open,
     setOpen,
@@ -17,10 +19,15 @@ function CurrentUserWidget() {
     y,
     strategy,
   } = useOptionMenu();
+  const logOut = useLogOut();
 
-  // render skeleton ui
-  if (isLoading) return <div />;
-  if (isError) return <div />;
+  if (!data) {
+    return (
+      <Button onClick={logOut} className="bg-red-700">
+        Sign in
+      </Button>
+    );
+  }
 
   return (
     <div className="px-2 font-pixel text-sm text-white">

--- a/src/organism/Chat.tsx
+++ b/src/organism/Chat.tsx
@@ -1,30 +1,12 @@
 import { useState } from 'react';
 import { useRecoilState, useSetRecoilState } from 'recoil';
-import { fetcher } from '@/hooks/fetcher';
-import { useQuery, useMutation } from '@tanstack/react-query';
 import { RoomInfo, roomInfoState } from '@/states/roomInfoState';
+import { RoomListType, useJoinRoom, useRoomList } from '@/hooks/chat';
 import SideBarLayout from '@/molecule/SideBarLayout';
 import SideBarHeader from '@/molecule/SideBarHeader';
 import SectionList from '@/molecule/SectionList';
 import ChatingRoom from '@/organism/ChatingRoom';
 import CreateChatForm from '@/organism/CreateChatForm';
-
-export type RoomListType = 'all' | 'joined';
-
-function useRoomList(type: RoomListType) {
-  const result = useQuery({
-    queryKey: ['chat/rooms', type],
-    queryFn: async (): Promise<RoomInfo[]> => {
-      const res = await fetcher(`/chat/rooms/${type}`);
-      if (res.ok) {
-        const data = await res.json();
-        return data.rooms;
-      }
-      return [];
-    },
-  });
-  return result;
-}
 
 const Chat = () => {
   const [roomInfo, setRoomInfo] = useRecoilState(roomInfoState); //room_id need to be null when user is not in any room
@@ -39,24 +21,6 @@ const Chat = () => {
     </SideBarLayout>
   );
 };
-
-function useJoinRoom() {
-  const setRoomInfo = useSetRecoilState(roomInfoState);
-  const mutation = useMutation({
-    mutationFn: async (room: RoomInfo) => {
-      return fetcher(`/chat/room/${room.room_id}/join`, {
-        method: 'POST',
-        body: JSON.stringify({ room_password: '' }),
-      });
-    },
-    onSuccess: (data, variables) => {
-      if (data.ok) {
-        setRoomInfo(variables ?? null);
-      }
-    },
-  });
-  return mutation;
-}
 
 function ChattingRoomList() {
   const [isOpenForm, setIsOpenForm] = useState(false);

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,9 +2,10 @@ import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 import { useMutation } from '@tanstack/react-query';
-import { fetcher } from '@/hooks/fetcher';
+import { useFetcher } from '@/hooks/fetcher';
 import { SignUpUserInfo, signUpUserInfoState } from '@/states/user/signUp';
 import { toast } from 'react-toastify';
+import { accessTokenState } from '@/states/user/auth';
 
 interface LoginParams {
   provider: string;
@@ -14,6 +15,9 @@ interface LoginParams {
 function useLoginMutation() {
   const navigate = useNavigate();
   const setSignupUserInfo = useSetRecoilState(signUpUserInfoState);
+  const setAccessToken = useSetRecoilState(accessTokenState);
+  const fetcher = useFetcher();
+
   const mutation = useMutation({
     mutationFn: async ({ code, provider }: LoginParams) => {
       const res = await fetcher(`/auth/oauth2/${provider}`, {
@@ -26,7 +30,7 @@ function useLoginMutation() {
     },
     onSuccess: (data) => {
       if ('access_token' in data) {
-        window.localStorage.setItem('access_token', data.access_token);
+        setAccessToken(data.access_token);
         window.localStorage.setItem('refresh_token', data.refresh_token);
         return navigate('/main');
       }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -8,6 +8,7 @@ import Friends from '@/organism/Friends';
 import Directmsg from '@/organism/Directmsg';
 import UserProfileModal from '@/organism/UserProfileModal';
 import GameContainer from "@/templates/GameContainer";
+import { useRefreshToken } from '@/hooks/user';
 
 function SidebarSelector() {
   const currentSideBarItem = useRecoilValue(currentSideBarItemState);
@@ -22,6 +23,7 @@ function SidebarSelector() {
 }
 
 function Main() {
+  useRefreshToken();
   useNotification();
 
   return (

--- a/src/states/user/auth.ts
+++ b/src/states/user/auth.ts
@@ -1,0 +1,42 @@
+import { atom, selector } from 'recoil';
+
+export const accessTokenState = atom<string | null>({
+  key: 'accessToken',
+  default: null,
+});
+
+export interface UserInfo {
+  user_id: string;
+  nickname: string;
+  provider: string;
+  third_party_id: string;
+  prof_img: string;
+  mmr: number;
+  two_factor_authentication_type?: string;
+  two_factor_authentication_key?: string;
+  created: Date;
+  deleted?: Date;
+}
+
+export const currentUserInfoState = selector<UserInfo | null>({
+  key: 'currentUserInfo',
+  get: ({ get }) => {
+    const accessToken = get(accessTokenState);
+    if (!accessToken) return null;
+    return parseJwt(accessToken);
+  },
+});
+
+function parseJwt(token: string): UserInfo {
+  const base64Url = token.split('.')[1];
+  const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+  const jsonPayload = decodeURIComponent(
+    window
+      .atob(base64)
+      .split('')
+      .map((c) => '%' + c.charCodeAt(0).toString(16).padStart(2, '0'))
+      .join(''),
+  );
+
+  return JSON.parse(jsonPayload);
+}

--- a/src/templates/GameContainer.tsx
+++ b/src/templates/GameContainer.tsx
@@ -1,7 +1,8 @@
-import {useRecoilState} from "recoil";
+import {useRecoilState, useRecoilValue} from "recoil";
 import {useEffect, useRef} from "react";
 
 import {currentGameStatus} from "@/states/game/currentGameStatus";
+import {accessTokenState} from "@/states/user/auth";
 
 import GameWindow from '@/organism/GameWindow';
 import GameOnMatching from "@/molecule/GameOnMatching";
@@ -18,7 +19,7 @@ const GameContainer = () => {
   const [currentStatus, setCurrentStatus] = useRecoilState(currentGameStatus);
 
   const gameSocketUri = `ws://54.164.253.231:9998`;
-  const accessToken = window.localStorage.getItem("access_token");
+  const accessToken = useRecoilValue(accessTokenState);
 
   const isFirstMount = useRef(true);
   const gameSocketManager = GameSocketManager.getInstance();


### PR DESCRIPTION
# Abstract

- access_token을 recoil atom으로 변경
  - Nav에 표시되는 UserProfileWidget을 해당 access_token을 디코딩해서 사용하도록 수정
  - access_token에 의존하던 fetcher를 recoil state를 사용하기위해 커스텀 훅으로 감싸도록 수정
- refresh_token으로 매 접속시마다 refresh 요청

## Types of edition

- [x] Changing feature (modifying existing feature or fixing bug)

# Test results

- [x] Compile succeed
