### PR TITLE
Fix GameContainer

### DIFF
--- a/src/templates/GameContainer.tsx
+++ b/src/templates/GameContainer.tsx
@@ -31,7 +31,7 @@ const GameContainer = () => {
 
     // socket should be initiated before using;
     gameSocketManager.initSocket(gameSocketUri, accessToken);
-    
+
     const gameSocket = gameSocketManager.socket;
     if (!gameSocket) { return; }
 
@@ -50,7 +50,7 @@ const GameContainer = () => {
     gameSocket.on("game_error", (error: any) => {
       console.log(error);
     });
-  },[]);
+  },[accessToken]);
 
   return (
     <div className="flex flex-col h-full w-full bg-neutral-900">


### PR DESCRIPTION
# Abstract

access_token을 recoil로 옮기면서 초기 /auth/refresh 에 대한 응답을 받기 전에는 access_token의 값이 null 인 상황이 발생합니다.
따라서 useEffect 훅의 의존성 목록에 access_token을 추가하여 원치 않게 코드가 실행되지 않는 것을 막았습니다.

## Types of edition

- [x] Bug fix (not modifying existing features)

# Test results

- [x] Compile succeed